### PR TITLE
Add CLI commands with data caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # bullwatcher
+
+Utility for collecting stock data and generating daily reports.
+
+## Usage
+
+```
+python main.py collect           # fetch data and save result/YYYY-MM-DD.csv
+python main.py report_console    # print sector report from latest data
+python main.py report_telegram   # send sector report to Telegram
+python main.py offer_console     # print top recommendations
+python main.py offer_telegram    # send top recommendations to Telegram
+```
+
+Run `collect` once per day before other commands, or rely on the report/offer
+commands to automatically load the most recent CSV in the `result` directory.


### PR DESCRIPTION
## Summary
- refactor `main.py` into a CLI with commands for collecting data, generating reports and offers
- cache daily results in `result/{today}.csv` and auto-load if present
- document CLI usage in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852a54897e48331ba4eb15a66be57a7