### PR TITLE
Add offer_history command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ python main.py report_console [YYYY-MM-DD]  # print sector report, optionally fr
 python main.py report_telegram [YYYY-MM-DD] # send sector report to Telegram
 python main.py offer_console [YYYY-MM-DD]   # print top recommendations
 python main.py offer_telegram [YYYY-MM-DD]  # send top recommendations to Telegram
+python main.py offer_history TICKER        # show dates when the ticker was recommended
 ```
 
 Run `collect` once per day before other commands, or rely on the report/offer


### PR DESCRIPTION
## Summary
- add new CLI option `offer_history`
- implement `offer_history` logic for scanning historical results
- document the new command in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852b15d7f008331bb6b78eb2a20a97c