### PR TITLE
Add sell recommendation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ python main.py report_telegram [YYYY-MM-DD] # send sector report to Telegram
 python main.py offer_console [YYYY-MM-DD]   # print top recommendations
 python main.py offer_telegram [YYYY-MM-DD]  # send top recommendations to Telegram
 python main.py offer_history TICKER        # show dates when the ticker was recommended
+python main.py sell_console                # show sell recommendations in console
+python main.py sell_telegram               # send sell recommendations to Telegram
+python main.py show_history TICKER         # display historical rows for ticker
 ```
 
 Run `collect` once per day before other commands, or rely on the report/offer

--- a/config.py.example
+++ b/config.py.example
@@ -7,6 +7,14 @@ TICKERS = [
     "ESLT", "KTOS", "AVAV"
 ]
 
+# List of tickers to analyze for sell recommendations
+SELL_TICKERS = [
+    "NVDA", "AMD", "MSFT", "GOOGL", "AMZN", "AAPL", "META", "TSLA",
+    "CRM", "ZS", "PANW", "SNOW", "DDOG", "REGN", "VRTX", "MRNA",
+    "PLTR", "ARKK", "ON", "ASML", "RTX", "LMT", "NOC", "GD", "LHX",
+    "ESLT", "KTOS", "AVAV"
+]
+
 RSI_THRESHOLD = 40
 PRICE_DROP_THRESHOLD = 5.0  # у відсотках
 


### PR DESCRIPTION
## Summary
- list SELL_TICKERS in `config.py.example`
- compute sell scores and produce a sale recommendation message
- load latest CSV without fetching new data
- CLI options for sell_console/sell_telegram/show_history
- document new commands

## Testing
- `python -m py_compile main.py config.py.example`


------
https://chatgpt.com/codex/tasks/task_e_6852bbfe1ab08331b67e44384dfeaad7