### PR TITLE
Add config variables for sell recommendations

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -15,6 +15,12 @@ SELL_TICKERS = [
     "ESLT", "KTOS", "AVAV"
 ]
 
+# Thresholds for sell recommendations
+SELL_RSI_THRESHOLD = 70
+SELL_GROWTH_THRESHOLD = 20  # percentage increase
+SELL_RECOMMENDATION_KEYS = ["sell", "underperform", "hold"]
+SELL_SCORE_THRESHOLD = 2
+
 RSI_THRESHOLD = 40
 PRICE_DROP_THRESHOLD = 5.0  # у відсотках
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,10 @@ from config import (
     RESULT_DIR,
     TELEGRAM_BOT_TOKEN,
     TELEGRAM_CHAT_ID,
+    SELL_RSI_THRESHOLD,
+    SELL_GROWTH_THRESHOLD,
+    SELL_RECOMMENDATION_KEYS,
+    SELL_SCORE_THRESHOLD,
 )
 import numpy as np
 import re
@@ -246,9 +250,9 @@ def top_recommendations(df, limit=5):
 
 def analyze_sell_signals(row):
     """Return sell score based on overbought conditions."""
-    rsi_flag = float(row["RSI"]) > 70
-    growth_flag = float(row["Price Change %"]) > 20
-    rec_flag = str(row["Recommendation"]).lower() in ["sell", "underperform", "hold"]
+    rsi_flag = float(row["RSI"]) > SELL_RSI_THRESHOLD
+    growth_flag = float(row["Price Change %"]) > SELL_GROWTH_THRESHOLD
+    rec_flag = str(row["Recommendation"]).lower() in SELL_RECOMMENDATION_KEYS
     return int(rsi_flag) + int(growth_flag) + int(rec_flag)
 
 
@@ -260,7 +264,7 @@ def sell_recommendations(df, limit=5):
     df = df[df["Ticker"].isin(SELL_TICKERS)]
     df = df[df["Error"].isnull()]
     df["Sell Score"] = df.apply(analyze_sell_signals, axis=1)
-    df = df[df["Sell Score"] >= 2]
+    df = df[df["Sell Score"] >= SELL_SCORE_THRESHOLD]
     df = df.sort_values(by=["Sell Score", "Price Change %"], ascending=[False, False]).head(limit)
 
     message = "\U0001F4E4 *Рекомендовані до продажу:*"
@@ -269,7 +273,7 @@ def sell_recommendations(df, limit=5):
         rsi = float(row["RSI"])
         change = float(row["Price Change %"])
         direction = "🔼🟢" if change > 0 else "🔽🔴"
-        rsi_mark = " 🚫" if rsi > 70 else ""
+        rsi_mark = " 🚫" if rsi > SELL_RSI_THRESHOLD else ""
 
         ticker = escape_markdown(row["Ticker"])
         name = escape_markdown(row["Company"]) if row.get("Company") else ""


### PR DESCRIPTION
## Summary
- allow configuring sell recommendation thresholds via config
- update example config with defaults

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852c412e8608331ac49622197b60aaa