### PR TITLE
Add norm change support to buy/sell signals

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -17,12 +17,14 @@ SELL_TICKERS = [
 
 # Thresholds for sell recommendations
 SELL_RSI_THRESHOLD = 70
-SELL_GROWTH_THRESHOLD = 20  # percentage increase
+SELL_GROWTH_THRESHOLD = 5  # percentage increase
+SELL_NORM_GROWTH_THRESHOLD = 2.0  # normalized increase vs 30d average
 SELL_RECOMMENDATION_KEYS = ["sell", "underperform", "hold"]
 SELL_SCORE_THRESHOLD = 2
 
 RSI_THRESHOLD = 40
 PRICE_DROP_THRESHOLD = 5.0  # у відсотках
+PRICE_NORM_DROP_THRESHOLD = 2.0  # drop vs 30d average
 
 RESULT_DIR = "result"
 

--- a/result/2024-01-01.csv
+++ b/result/2024-01-01.csv
@@ -1,0 +1,2 @@
+Ticker,Company,Sector,Current Price,Open Price (month),Price Change %,Price Norm Change %,Normalized Price Change %,RSI,Below 30d Avg,RSI_check,Drop_check,Recommendation,Target Mean Price,Error
+NVDA,NVIDIA,Technology,100,90,11.11,3.33,5.0,55,False,False,False,buy,120,


### PR DESCRIPTION
## Summary
- add thresholds for normalised price changes
- include Price Norm Change % in analysis
- compute buy/sell scores with normalised metrics
- show 30d normalised changes in messages
- provide example result file with the new column

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852d6dc4d0083318a8b2e0dbe9e8cd8